### PR TITLE
fix(集卡布局): 移动端优化按钮显示和卡片留白问题

### DIFF
--- a/src/app/overwatch-market/page.tsx
+++ b/src/app/overwatch-market/page.tsx
@@ -267,9 +267,10 @@ export default function OverwatchMarketPage() {
               <span className="hidden sm:inline">社区模板</span>
               <span className="sm:hidden">模板</span>
             </Link>
-            <div className="sm:hidden">
-              <AppreciationButton className="text-xs px-3 py-2" />
-            </div>
+            <AppreciationButton 
+              variant="custom"
+              className="sm:hidden inline-flex items-center justify-center gap-1 sm:gap-1.5 px-3 py-2 bg-gray-800/50 hover:bg-gray-700/50 text-gray-300 hover:text-white rounded-lg transition-all duration-200 border border-gray-700/50 hover:border-gray-600/50 text-xs sm:text-sm whitespace-nowrap" 
+            />
           </div>
           <div className="hidden sm:flex items-center flex-shrink-0">
             <AppreciationButton className="text-sm" />

--- a/src/components/AppreciationModal.tsx
+++ b/src/components/AppreciationModal.tsx
@@ -97,21 +97,37 @@ const AppreciationModal: React.FC = () => {
 // 触发按钮组件
 interface AppreciationButtonProps {
   className?: string;
+  variant?: 'default' | 'custom';
 }
 
-export const AppreciationButton: React.FC<AppreciationButtonProps> = ({ className = '' }) => {
+export const AppreciationButton: React.FC<AppreciationButtonProps> = ({ className = '', variant = 'default' }) => {
   const { openModal } = useAppreciation();
+
+  const defaultClasses = "flex items-center gap-2 px-4 py-2 bg-gradient-to-r from-pink-600/20 to-pink-700/20 border border-pink-500/30 rounded-lg hover:from-pink-600/30 hover:to-pink-700/30 hover:border-pink-400/50 transition-all duration-200 group";
+  
+  const buttonClasses = variant === 'custom' ? className : `${defaultClasses} ${className}`;
 
   return (
     <button
       onClick={openModal}
-      className={`flex items-center gap-2 px-4 py-2 bg-gradient-to-r from-pink-600/20 to-pink-700/20 border border-pink-500/30 rounded-lg hover:from-pink-600/30 hover:to-pink-700/30 hover:border-pink-400/50 transition-all duration-200 group ${className}`}
+      className={buttonClasses}
     >
-      <span className="text-lg">💖</span>
-      <span className="text-white text-sm font-medium">赞赏支持</span>
-      <svg className="w-4 h-4 text-pink-400 transform group-hover:scale-110 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
-      </svg>
+      {variant === 'default' && <span className="text-lg">💖</span>}
+      {variant === 'custom' && <span className="text-sm sm:text-lg">💖</span>}
+      {variant === 'default' && (
+        <>
+          <span className="text-white text-sm font-medium">赞赏支持</span>
+          <svg className="w-4 h-4 text-pink-400 transform group-hover:scale-110 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
+          </svg>
+        </>
+      )}
+      {variant === 'custom' && (
+        <>
+          <span className="hidden sm:inline text-white text-sm font-medium">赞赏支持</span>
+          <span className="sm:hidden text-white text-xs font-medium">赞赏</span>
+        </>
+      )}
     </button>
   );
 };

--- a/src/components/CardFilter.tsx
+++ b/src/components/CardFilter.tsx
@@ -61,10 +61,27 @@ function SimpleCardSelector({ title, selectedCardId, onCardChange, placeholder, 
   useEffect(() => {
     if (isOpen && buttonRef.current) {
       const rect = buttonRef.current.getBoundingClientRect();
+      const viewportWidth = window.innerWidth;
+      const maxWidth = Math.min(viewportWidth - 32, 400); // 最大宽度不超过视口宽度减去边距
+      
+      // 确保下拉菜单与按钮左对齐，同时不超出屏幕边界
+      let left = rect.left + window.scrollX;
+      const width = Math.max(rect.width, Math.min(maxWidth, 320));
+      
+      // 如果下拉菜单会超出右边界，则向左调整
+      if (left + width > viewportWidth - 16) {
+        left = viewportWidth - width - 16;
+      }
+      
+      // 确保不超出左边界
+      if (left < 16) {
+        left = 16;
+      }
+      
       setDropdownPosition({
         top: rect.bottom + window.scrollY + 4,
-        left: rect.left + window.scrollX,
-        width: Math.max(rect.width, 400)
+        left: left,
+        width: width
       });
     }
   }, [isOpen]);
@@ -99,7 +116,7 @@ function SimpleCardSelector({ title, selectedCardId, onCardChange, placeholder, 
 
   const dropdownContent = (
     <div 
-      className="bg-gray-800/95 border border-gray-600/50 rounded-lg shadow-2xl overflow-hidden backdrop-blur-md"
+      className="bg-gray-800/95 border border-gray-600/50 rounded-lg shadow-2xl overflow-hidden backdrop-blur-md max-w-[calc(100vw-32px)]"
       style={{
         position: 'absolute',
         top: dropdownPosition.top,
@@ -111,7 +128,7 @@ function SimpleCardSelector({ title, selectedCardId, onCardChange, placeholder, 
       {/* 赛区快速选择 */}
       <div className="p-3 border-b border-gray-700/50">
         <div className="text-xs font-medium text-gray-400 mb-2">选择赛区</div>
-        <div className="grid grid-cols-5 gap-1">
+        <div className="grid grid-cols-3 sm:grid-cols-5 gap-1">
           {Object.entries(regions).map(([key, region]) => (
             <button
               key={key}
@@ -176,7 +193,7 @@ function SimpleCardSelector({ title, selectedCardId, onCardChange, placeholder, 
       
       {/* 卡片网格 */}
       <div className="max-h-48 overflow-y-auto p-2">
-        <div className="grid grid-cols-6 gap-1">
+        <div className="grid grid-cols-4 sm:grid-cols-5 lg:grid-cols-6 gap-1">
           {filteredCards.map(cardId => {
             const card = getCardRegionAndNumber(cardId);
             return (


### PR DESCRIPTION
部分移动端出现卡片宽度超出容器留白问题：
<img width="412" height="310" alt="卡片修复前" src="https://github.com/user-attachments/assets/7ff73315-3aa3-440c-9e76-8d7b317bc2b4" />

修复后：
<img width="404" height="317" alt="卡片修复后" src="https://github.com/user-attachments/assets/39bcaca7-f9e2-4d3d-aae9-4f2c33175fd2" />

优化按钮显示问题：
<img width="409" height="121" alt="按钮优化前" src="https://github.com/user-attachments/assets/201f24cf-4bd9-42ee-97af-e2699cc0b1be" />

修复后：
<img width="488" height="106" alt="按钮优化后" src="https://github.com/user-attachments/assets/1c4df533-1027-477f-8696-00c949b90ddc" />

